### PR TITLE
Feat/deploy on conda forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,18 @@ Standalone charge assignment from Espaloma framework. https://doi.org/10.1039/D2
 
 ## Installation
 
+### Pip
+
 ```bash
 $ pip install espaloma_charge
 ```
+
+### Conda-Forge
+
+```bash
+$ conda install -c conda-forge espaloma_charge
+```
+
 
 ## Examples
 **Option0: Assign charges to rdkit molecule.**

--- a/README.md
+++ b/README.md
@@ -14,9 +14,8 @@ $ pip install espaloma_charge
 ### Conda-Forge
 
 ```bash
-$ conda install -c conda-forge espaloma_charge
+$ conda install -c conda-forge -c dglteam dgl espaloma_charge
 ```
-
 
 ## Examples
 **Option0: Assign charges to rdkit molecule.**

--- a/espaloma_charge/app.py
+++ b/espaloma_charge/app.py
@@ -2,11 +2,6 @@ import os
 import tempfile
 from urllib import request
 from rdkit import Chem
-import dgl
-try:
-    dgl.use_libxsmm(False)
-except:
-    pass
 import torch
 from torch.utils.model_zoo import load_url
 import numpy as np

--- a/espaloma_charge/app.py
+++ b/espaloma_charge/app.py
@@ -7,6 +7,12 @@ from torch.utils.model_zoo import load_url
 import numpy as np
 from .utils import from_rdkit_mol
 
+try:
+    import dgl
+    dgl.use_libxsmm(False)
+except:
+    pass
+
 # TODO: Do we really want to define this at file level, rather than within some kind of class?
 MODEL_URL = """
 https://github.com/choderalab/espaloma_charge/releases/download/v0.0.7/model.pt


### PR DESCRIPTION
DGL isn't yet on conda-forge (this is still on my todo list but has fallen behind other things) so I had to remove an import (I didn't have to but I like to have an import test) but it looks like `dgl` isn't used in `app.py` so it should be okay? Unless setting `dgl.use_libxsmm(False)` is important, even if `dgl` isn't used. It looks like you set that option in other places. 

Let me know if this looks okay! 