### PR TITLE
improve CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,16 @@
 name: Python Package using Conda
 
-on: [push]
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    # At 07:00 UTC on Monday and Thursday.
+    - cron: "0 7 * * 1,4"
+  workflow_dispatch:
 
 defaults:
   run:
@@ -12,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.8", "3.10"]
 
     steps:
@@ -26,13 +36,13 @@ jobs:
 
     - name: Install dependencies
       run: |
-        #conda env update --file environment.yml --name base
         pip install . --no-deps
 
     - name: Environment Information
       run: |
         conda info
         conda list
+
     - name: Test with pytest
       run: |
-        pytest espaloma_charge
+        pytest -v espaloma_charge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
     branches:
       - main
   schedule:
-    # At 07:00 UTC on Monday and Thursday.
-    - cron: "0 7 * * 1,4"
+    # At 01:02 UTC everyday.
+    - cron: "02 1 * * *"
   workflow_dispatch:
 
 defaults:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Espaloma Charge
 =======
 
+[![CI](https://github.com/choderalab/espaloma_charge/actions/workflows/ci.yml/badge.svg)](https://github.com/choderalab/espaloma_charge/actions/workflows/ci.yml)
+
 Standalone charge assignment from Espaloma framework. https://doi.org/10.1039/D2SC02739A
 
 ## Installation


### PR DESCRIPTION
This PR:
 * Sets up our CI to run at 07:00 UTC on Monday and Thursday.
 * Runs tests on ubuntu and macos
 * Runs on PRs targeting main + when we merge to main (instead on every commit)
 * Improves the output of pytest
 * Removes commented out code