### PR TITLE
see which dlg + openff toolkit  versions work with espaloma_charge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, macos-13]
-        python-version: ["3.9", "3.11"]
+        python-version: ["3.9", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, macos-13]
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.9", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, macos-13]
-        python-version: ["3.9", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-13]
+        os: [ubuntu-latest, macos-latest, macos-12]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:

--- a/environment.yml
+++ b/environment.yml
@@ -5,8 +5,8 @@ channels:
   - conda-forge
 dependencies:
   - python
-  - openff-toolkit >=0.14.*,<0.15
+  - openff-toolkit >=0.14.*,<0.17
   - pytest
   - pytorch
-  - dgl==1.1.3
+  - dgl ~==1.1.2
   - torchdata

--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,5 @@ dependencies:
   - openff-toolkit >=0.14.*,<0.17
   - pytest
   - pytorch
-  - dgl ~==1.1.2
+  - dgl ~=1.1.2
   - torchdata

--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,5 @@ dependencies:
   - openff-toolkit >=0.14.*
   - pytest
   - pytorch
-  - dgl ~=2
+  - dgl ~=2.
   - torchdata

--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,5 @@ dependencies:
   - openff-toolkit >=0.14.*
   - pytest
   - pytorch
-  - dgl ~=1.1.2
+  - dgl ~=2
   - torchdata

--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,5 @@ dependencies:
   - openff-toolkit >=0.14.*,<0.15
   - pytest
   - pytorch
-  - dgl==1.1.2
+  - dgl==1.1.3
   - torchdata

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - conda-forge
 dependencies:
   - python
-  - openff-toolkit >=0.14.*,<0.17
+  - openff-toolkit >=0.14.*
   - pytest
   - pytorch
   - dgl ~=1.1.2


### PR DESCRIPTION
If this works then we can adjust the pin our our conda-forge package, which would allow users with osx-arm64 to install espaloma_charge from conda-forge